### PR TITLE
Load environment variables from .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "groq-sdk": "*",
     "node-cron": "*",
     "probot": "*",
-    "zod": "*"
+    "zod": "*",
+    "dotenv": "*"
   },
   "devDependencies": {
     "@types/node": "*",

--- a/src/jobs/retro.ts
+++ b/src/jobs/retro.ts
@@ -1,3 +1,6 @@
+import dotenv from "dotenv";
+dotenv.config();
+
 import { db } from "../db";
 import Groq from "groq-sdk";
 import { Octokit } from "@octokit/rest";

--- a/src/jobs/standup.ts
+++ b/src/jobs/standup.ts
@@ -1,3 +1,6 @@
+import dotenv from "dotenv";
+dotenv.config();
+
 import { db } from "../db";
 import Groq from "groq-sdk";
 import { Octokit } from "@octokit/rest";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,9 @@
+import dotenv from "dotenv";
+dotenv.config();
+
 import { Probot } from "probot";
 import Fastify from "fastify";
 import { db } from "./db";
-import * as process from "node:process";
 import cron from "node-cron";
 import { exec } from "child_process";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node", "node-fetch"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in server and job scripts
- expose Node and node-fetch type definitions
- declare `dotenv` dependency

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6576926a483209a512d0fc35d5788