### PR TITLE
Fix Probot webhooks configuration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,9 @@ const fastify = Fastify();
 const app = new Probot({
   appId: Number(process.env.APP_ID),
   privateKey: process.env.PRIVATE_KEY!,
-  secret: process.env.WEBHOOK_SECRET!,
+  webhooks: {
+    secret: process.env.WEBHOOK_SECRET!,
+  },
 });
 
 // Ingest helpers


### PR DESCRIPTION
## Summary
- initialize Probot with `webhooks.secret` to avoid null webhooks object

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68a65c5354fc8320b3b4771d38f60029