### PR TITLE
fix: update Probot webhook secret configuration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -11,9 +11,7 @@ const fastify = Fastify();
 const app = new Probot({
   appId: Number(process.env.APP_ID),
   privateKey: process.env.PRIVATE_KEY!,
-  webhooks: {
-    secret: process.env.WEBHOOK_SECRET!,
-  },
+  secret: process.env.WEBHOOK_SECRET!,
 });
 
 // Ingest helpers


### PR DESCRIPTION
## Summary
- update Probot initialization to use `secret` option instead of unsupported `webhooks` object

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68a66235c5608320b3794de7eb829eee